### PR TITLE
Fixes AttentionCouplePPM node not working with API workflow

### DIFF
--- a/js/attention_couple_ppm.js
+++ b/js/attention_couple_ppm.js
@@ -33,6 +33,34 @@ app.registerExtension({
                 return r;
 
             }
+
+            const onConnectionsChange = nodeType.prototype.onConnectionsChange;
+			nodeType.prototype.onConnectionsChange = function (type, index, connected, link_info) {
+                let cond_input_name = "cond_";
+                let mask_input_name = "mask_";
+                let slot_i = 1;
+
+                // Count existing input slots
+                for (let i = 0; i < this.inputs.length; i++) {
+                    let input_i = this.inputs[i];
+                    if (input_i.name.startsWith(mask_input_name)) {
+                        slot_i++;
+                    }
+                }
+
+                let last_slot = this.inputs[this.inputs.length - 1];
+                let second_last_slot = this.inputs[this.inputs.length - 2];
+
+                // Check if the last two slots are connected
+                if (
+                    (second_last_slot.link != undefined)
+                    && (last_slot.link != undefined)
+                ) {
+                    // Add new 'cond' and 'mask' slots
+                    this.addInput(`${cond_input_name}${slot_i}`, "CONDITIONING");
+                    this.addInput(`${mask_input_name}${slot_i}`, "MASK");
+                }
+            }
         }
     },
 });


### PR DESCRIPTION
When using AttentionCouplePPM through a workflow API added regions (cond_# and mask_#) aren't connected (Try loading this workflow to see the issue: [AttentionCouple_PPM_API.json](https://github.com/user-attachments/files/16710889/AttentionCouple_PPM_API.json)). 

This seems to be because extra region inputs are currently only added with the `Add Region` button in the context menu, since the API workflow spawns the node and tries to connect the inputs it doesn't know about the additional inputs so it fails to connect them. Other custom nodes seem to handle this situation by subscribing to `nodeType.prototype.onConnectionsChange` then using that to automatically add the extra input slots when the previous ones have been connected.

This pull request adds that functionality, when `model` and `base_mask` are connected it will automatically add `cond_1` and `mask_1` inputs (As if you clicked add region), then if those are linked it will automatically create `cond_2` and `mask_2`, and so on. The existing add and remove region buttons still work and the attached API workflow json will now load.